### PR TITLE
upgrade dependencies, remove AOT compilation as compiling the lib wit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+## [0.1.9] - 2019-08-20
+### Upgrade dependencies
+### Remove AOT as compiling with clojure 1.8 was causing problems to potemkin from other dependencies 
+
 ## [0.1.8] - 2016-10-25
 ### Upgrade dependencies
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ requirements of your network.
 
 Leiningen:
 ```
-[metrics-statsd "0.1.8"]
+[metrics-statsd "0.1.9"]
 ```
 
 Maven:
@@ -31,7 +31,7 @@ Maven:
 <dependency>
   <groupId>metrics-statsd</groupId>
   <artifactId>metrics-statsd</artifactId>
-  <version>0.1.8</version>
+  <version>0.1.9</version>
 </dependency>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -12,17 +12,15 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject metrics-statsd "0.1.8"
+(defproject metrics-statsd "0.1.9"
   :description "A batching StatsD reporter for Coda Hale's metrics library"
   :url "https://github.com/orgsync/metrics-statsd"
   :license {:name "Apache 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[aleph "0.4.2-alpha8"]
-                 [byte-streams "0.2.2"]
+  :dependencies [[aleph "0.4.6"]
+                 [byte-streams "0.2.4"]
                  [gloss "0.2.6"]
-                 [io.dropwizard.metrics/metrics-core "3.1.2"]
-                 [manifold "0.1.6-alpha3"]
-                 [org.clojure/clojure "1.8.0"]]
-  :aot [metrics-statsd.core]
-  :jvm-opts ["-Dclojure.compiler.direct-linking=true"]
-  :profiles {:dev {:dependencies [[criterium "0.4.4"]]}})
+                 [io.dropwizard.metrics/metrics-core "3.2.2"]
+                 [manifold "0.1.8"]
+                 [org.clojure/clojure "1.10.1"]]
+  :profiles {:dev {:dependencies [[criterium "0.4.5"]]}})


### PR DESCRIPTION
…h clojure 1.8 messes up potemkin macros from other dependencies